### PR TITLE
Update remove-excess-files.js

### DIFF
--- a/remove-excess-files.js
+++ b/remove-excess-files.js
@@ -19,8 +19,13 @@ module.exports = function (context) {
 
 //Anchor to platform root
     context.opts.cordova.platforms.forEach(function(platform) {
-		//Platform www directory path
-		var pwww = "platforms/" + platform + "/assets/www/";
+		 //Platform www directory path
+	        if (platform === 'windows') {
+	            var pwww = "platforms/windows/www/";
+	        } else {
+	            var pwww = "platforms/" + platform + "/assets/www/";
+	        }
+        
 		
 	//Remove unminified js and css if minified exists.
 		jsCssPattern = "@(*.css|*.js)";


### PR DESCRIPTION
The www folder for the windows build does not reside inside assets. Hence the work path gets initialized incorrectly and no files are removed. With the added conditional the correct path will be used and the plugin also works as expected for windows builds.
